### PR TITLE
Adding an example to run TurtleBot3 SLAM Mapping application

### DIFF
--- a/example/AppxManifest.xml
+++ b/example/AppxManifest.xml
@@ -60,9 +60,8 @@
       <uap6:LoaderSearchPathOverride>
         <uap6:LoaderSearchPathEntry FolderPath="VFS\Common AppData\python27amd64" />
         <uap6:LoaderSearchPathEntry FolderPath="VFS\Common AppData\ros\melodic\x64\bin" />
-        <uap6:LoaderSearchPathEntry FolderPath="VFS\Common AppData\ros\melodic\x64\lib" />
         <uap6:LoaderSearchPathEntry FolderPath="VFS\Common AppData\rosdeps\x64\bin" />
-        <uap6:LoaderSearchPathEntry FolderPath="VFS\Common AppData\rosdeps\x64\lib" />
+        <uap6:LoaderSearchPathEntry FolderPath="VFS\Common AppData\rosdeps\x64\lib\gazebo-9\plugins" />
       </uap6:LoaderSearchPathOverride>
     </uap6:Extension>
     <desktop2:Extension Category="windows.firewallRules">

--- a/example/Launcher.bat
+++ b/example/Launcher.bat
@@ -5,5 +5,13 @@ call C:\ProgramData\ros\melodic\x64\local_setup.bat
 :: activate the additional workspace
 :: call C:\ProgramData\install\setup.bat
 
-:: invoke roslaunch
+:: invoke talker_listener example
 roslaunch rospy_tutorials talker_listener.launch
+
+:: another example to invoke TurtleBot3 SLAM with RViz and Gazebo
+:: some environment variables are required for libraries to look for the correct runtime locations
+
+:: set TURTLEBOT3_MODEL=waffle
+:: set "CARTOGRAPHER_CONFIG_DIR=C:\ProgramData\ros\melodic\x64\share\cartographer\configuration_files"
+:: set "SDF_PATH=C:\ProgramData\rosdeps\x64\share\sdformat\1.6"
+:: roslaunch turtlebot3_gazebo turtlebot3_gazebo_cartographer_demo.launch

--- a/rosprep.ps1
+++ b/rosprep.ps1
@@ -43,12 +43,13 @@ Write-Host "`nRemoving working folder ... done`n"
 Write-Host "`nCopying ROS install ... `n"
 
 # exclude development time required files
+# * some packages have runtime dependency on pkg-config
+#   so we don't remove them for now.
 $developmentFiles = @(
     '*.lib',
     '*.pdb',
     '*.dll.a',
-    '*.cmake',
-    '*.pc'
+    '*.cmake'
 )
 
 $runtimeFolders = @(
@@ -83,6 +84,27 @@ foreach ($runtimeFolder in $runtimeFolders) {
 Copy-Item -Path (Join-Path $inputRosDir 'ros\melodic\x64\*.*') -Destination (Join-Path $outputRosDir 'ros\melodic\x64') -Container
 
 Write-Host "`nCopying ROS install ... done`n"
+
+Write-Host "`nFixing up shared library location ...`n"
+
+$fixupFolders = @(
+    'rosdeps\x64',
+    'ros\melodic\x64'
+)
+
+foreach ($fixupFolder in $fixupFolders) {
+    $outputDir = (Join-Path $outputRosDir $fixupFolder)
+    $sharedLibs = (Join-Path $outputDir "lib\*.dll")
+    $binDir = (Join-Path $outputDir "bin")
+    $arguments = @{
+        Path = $sharedLibs
+        Destination = $binDir
+        Force = $True
+    }
+    Move-Item @arguments
+}
+
+Write-Host "`nFixing up shared library location ...`n"
 
 Write-Host "`nGenerating the baseline firewall rules ... `n"
 


### PR DESCRIPTION
Adding an example how to run TurtleBot3 SLAM Mapping application with Rviz and Gazebo.

Along with that, some fixes up are also added to the `rosprep.ps1` and `AppxManifest.xml` to help easier ROS on MSIX packaging.

* In MSIX container, the default DLL search path is the root folder of the package and `%PATH%` makes no effect here. For any additional locations, one needs to define `LoaderSearchPathEntry` adding the additional locations. However, one app can only take up to 5 entries. To save the entries, in `rosprep.ps1`, it consolidates the `*.DLL` into `bin` folders as a fix-up pass. (Ideally all DLLs should be placed to `bin` by the upstream package.)

* Also make a exception copying `pkg-config` files into the MSIX packages. Some ROS packages have runtime dependency on the `pkg-config` files to discover the locations of a library. (Ideally `pkg-config` is a development-time tool, which should be discouraged at runtime.)

* Adding an entry of `LoaderSearchPathEntry` for Gazebo plugins. (Alternatively, we may consider to update Gazebo to use this [DLL search mechanism](https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order) for better support with the packaged app.) 

This change is verified against two more relocatable changes:
* cartographer: https://github.com/ms-iot/cartographer/commit/deeee03715095ab338976c1f6452ead9d8b7b7e8
* rviz: https://github.com/ms-iot/rviz/commit/812e175fc20de6a1760517186120dbf9d60a1bc3